### PR TITLE
CI: Bump OS versions

### DIFF
--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           echo $PYENV_ROOT
           echo "$PYENV_ROOT/shims:$PYENV_ROOT/bin" >> $GITHUB_PATH
-          bin/pyenv install ${{ matrix.python-version }}
+          bin/pyenv install -v ${{ matrix.python-version }}
           bin/pyenv global ${{ matrix.python-version }}
           bin/pyenv rehash
       - run: python --version

--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -10,7 +10,7 @@ jobs:
           - 3.8.13
           - 3.9.13
           - 3.10.6
-    runs-on: macos-10.15
+    runs-on: macos-11
     steps:
       - uses: actions/checkout@v2
       # Normally, we would use the superbly maintained...

--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -6,10 +6,10 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - 3.7.10
-          - 3.8.10
-          - 3.9.5
-          - 3.10.0
+          - 3.7.13
+          - 3.8.13
+          - 3.9.13
+          - 3.10.6
     runs-on: macos-10.15
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/modified_scripts_build.yml
+++ b/.github/workflows/modified_scripts_build.yml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ${{fromJson(needs.discover_modified_scripts.outputs.versions)}}
-        os: ["macos-10.15", "macos-11"]
+        os: ["macos-11", "macos-12"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -77,7 +77,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ${{fromJson(needs.discover_modified_scripts.outputs.versions)}}
-        os: ["ubuntu-18.04", "ubuntu-20.04"]
+        os: ["ubuntu-20.04", "ubuntu-22.04"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/modified_scripts_build.yml
+++ b/.github/workflows/modified_scripts_build.yml
@@ -38,7 +38,7 @@ jobs:
           echo "PYENV_ROOT=$PYENV_ROOT" >> $GITHUB_ENV
           echo "$PYENV_ROOT/shims:$PYENV_ROOT/bin" >> $GITHUB_PATH
       - run: |
-          pyenv install ${{ matrix.python-version }}
+          pyenv install -v ${{ matrix.python-version }}
           pyenv global ${{ matrix.python-version }}
       # Micropython doesn't support --version
       - run: >
@@ -91,7 +91,7 @@ jobs:
           echo "PYENV_ROOT=$PYENV_ROOT" >> $GITHUB_ENV
           echo "$PYENV_ROOT/shims:$PYENV_ROOT/bin" >> $GITHUB_PATH
       - run: |
-          pyenv install ${{ matrix.python-version }}
+          pyenv install -v ${{ matrix.python-version }}
           pyenv global ${{ matrix.python-version }}
       # Micropython doesn't support --version
       - run: >

--- a/.github/workflows/modified_scripts_build.yml
+++ b/.github/workflows/modified_scripts_build.yml
@@ -12,7 +12,7 @@ jobs:
         run: >
           versions=$(git diff "origin/$GITHUB_BASE_REF" --name-only -z
           | perl -ne 'BEGIN {$\="\n";$/="\0";} chomp;
-            if (/^plugins\/python-build\/share\/python-build\/(?:([^\/]+)|patches\/([^\/]+)\/.*)$/)
+            if (/^plugins\/python-build\/share\/python-build\/(?:([^\/]+)|patches\/([^\/]+)\/.*)$/ and -e $& )
                 { print $1.$2; }' \
           | sort -u);
           echo -e "versions<<!\\n$versions\\n!" >> $GITHUB_ENV

--- a/.github/workflows/modified_scripts_build.yml
+++ b/.github/workflows/modified_scripts_build.yml
@@ -40,20 +40,31 @@ jobs:
       - run: |
           pyenv install ${{ matrix.python-version }}
           pyenv global ${{ matrix.python-version }}
-      - run: |
-          python --version
-          python -m pip --version
-      - shell: python  # Prove that actual Python == expected Python
-        env:
+      # Micropython doesn't support --version
+      - run: >
+          if [[ "${{ matrix.python-version }}" == "micropython-"* ]]; then
+            python -c 'import sys; print(sys.version)'
+          else
+            python --version;
+            python -m pip --version
+          fi
+      # Micropython doesn't support sys.executable, os.path, older versions even os
+      - env:
           EXPECTED_PYTHON: ${{ matrix.python-version }}
         run: |
-          import os, sys, os.path
-          correct_dir = os.path.join(
-              os.environ['PYENV_ROOT'],
-              'versions',
-              os.environ['EXPECTED_PYTHON'],
-              'bin')
-          assert os.path.dirname(sys.executable) == correct_dir
+          if [[ "${{ matrix.python-version }}" == "micropython-"* ]]; then
+            [[ $(pyenv which python) == "${{ env.PYENV_ROOT }}/versions/${{ matrix.python-version }}/bin/python" ]] || exit 1
+            python -c 'import sys; assert sys.implementation.name == "micropython"'
+          else
+            python -c 'if True:
+            import os, sys, os.path
+            correct_dir = os.path.join(
+              os.environ["PYENV_ROOT"],
+              "versions",
+              os.environ["EXPECTED_PYTHON"],
+              "bin")
+            assert os.path.dirname(sys.executable) == correct_dir'
+          fi
       # bundled executables in some Anaconda releases cause the post-run step to hang in MacOS
       - run: |
           pyenv global system
@@ -82,16 +93,28 @@ jobs:
       - run: |
           pyenv install ${{ matrix.python-version }}
           pyenv global ${{ matrix.python-version }}
-      - run: python --version
-      - run: python -m pip --version
-      - shell: python  # Prove that actual Python == expected Python
-        env:
+      # Micropython doesn't support --version
+      - run: >
+          if [[ "${{ matrix.python-version }}" == "micropython-"* ]]; then
+            python -c 'import sys; print(sys.version)'
+          else
+            python --version;
+            python -m pip --version
+          fi
+      # Micropython doesn't support sys.executable, os.path, older versions even os
+      - env:
           EXPECTED_PYTHON: ${{ matrix.python-version }}
         run: |
-          import os, sys, os.path
-          correct_dir = os.path.join(
-              os.environ['PYENV_ROOT'],
-              'versions',
-              os.environ['EXPECTED_PYTHON'],
-              'bin')
-          assert os.path.dirname(sys.executable) == correct_dir
+          if [[ "${{ matrix.python-version }}" == "micropython-"* ]]; then
+            [[ $(pyenv which python) == "${{ env.PYENV_ROOT }}/versions/${{ matrix.python-version }}/bin/python" ]] || exit 1
+            python -c 'import sys; assert sys.implementation.name == "micropython"'
+          else
+            python -c 'if True:
+            import os, sys, os.path
+            correct_dir = os.path.join(
+              os.environ["PYENV_ROOT"],
+              "versions",
+              os.environ["EXPECTED_PYTHON"],
+              "bin")
+            assert os.path.dirname(sys.executable) == correct_dir'
+          fi

--- a/.github/workflows/pyenv_tests.yml
+++ b/.github/workflows/pyenv_tests.yml
@@ -6,10 +6,10 @@ jobs:
       fail-fast: false
       matrix:
         os:
+          - ubuntu-22.04
           - ubuntu-20.04
-          - ubuntu-18.04
+          - macos-12
           - macos-11
-          - macos-10.15
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -10,7 +10,7 @@ jobs:
           - 3.8.13
           - 3.9.13
           - 3.10.6
-    runs-on: Ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       # Normally, we would use the superbly maintained...

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -6,10 +6,10 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - 3.7.10
-          - 3.8.10
-          - 3.9.5
-          - 3.10.0
+          - 3.7.13
+          - 3.8.13
+          - 3.9.13
+          - 3.10.6
     runs-on: Ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           echo $PYENV_ROOT
           echo "$PYENV_ROOT/shims:$PYENV_ROOT/bin" >> $GITHUB_PATH
-          bin/pyenv install ${{ matrix.python-version }}
+          bin/pyenv install -v ${{ matrix.python-version }}
           bin/pyenv global ${{ matrix.python-version }}
           bin/pyenv rehash
       - run: python --version

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -238,9 +238,9 @@ To install the latest major release for Python 3 try:
 
 ## `pyenv uninstall`
 
-Uninstall a specific Python version.
+Uninstall Python versions.
 
-    Usage: pyenv uninstall [-f|--force] <version>
+    Usage: pyenv uninstall [-f|--force] <version> ...
 
        -f  Attempt to remove the specified version without prompting
            for confirmation. If the version does not exist, do not

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ General guidance
   (They didn't upgrade past it and switched to Zsh because later versions
   are covered by GPLv3 which has additional restrictions unacceptable for Apple.)
   
-  You can still add performance optimizations and such that take advantage of newer Bash features
+  You can still add performance optimizations etc that take advantage of newer Bash features
   as long as there is a fallback execution route for Bash 3.
 
 * Be extra careful when submitting logic specific for the Apple Silicon platform

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,9 @@ General guidance
   That's because that's the version shipped with MacOS.
   (They didn't upgrade past it and switched to Zsh because later versions
   are covered by GPLv3 which has additional restrictions unacceptable for Apple.)
+  
+  You can still add performance optimizations and such that take advantage of newer Bash features
+  as long as there is a fallback execution route for Bash 3.
 
 * Be extra careful when submitting logic specific for the Apple Silicon platform
 

--- a/README.md
+++ b/README.md
@@ -432,7 +432,7 @@ for more details on how the selection works and more information on its usage.
 As time goes on, you will accumulate Python versions in your
 `$(pyenv root)/versions` directory.
 
-To remove old Python versions, use [`pyenv uninstall <version>`](COMMANDS.md#pyenv-uninstall).
+To remove old Python versions, use [`pyenv uninstall <versions>`](COMMANDS.md#pyenv-uninstall).
 
 Alternatively, you can simply `rm -rf` the directory of the version you want
 to remove. You can find the directory of a particular Python version

--- a/man/man1/pyenv.1
+++ b/man/man1/pyenv.1
@@ -106,7 +106,7 @@ Set or show the shell\-specific Python version
 List existing pyenv shims
 .TP
 .B uninstall
-Uninstall a specific Python version
+Uninstall Python versions
 .TP
 .B version
 Show the current Python version(s) and its origin
@@ -452,10 +452,10 @@ $ pyenv versions
 .fi
 .IP "" 0
 .SS "pyenv uninstall"
-Uninstall a specific Python version\.
+Uninstall Python versions\.
 .IP "" 4
 .nf
-Usage: pyenv uninstall [\-f|\-\-force] <version>
+Usage: pyenv uninstall [\-f|\-\-force] <version> ...
 
    \-f  Attempt to remove the specified version without prompting
        for confirmation\. If the version does not exist, do not

--- a/plugins/python-build/bin/pyenv-uninstall
+++ b/plugins/python-build/bin/pyenv-uninstall
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 #
-# Summary: Uninstall a specific Python version
+# Summary: Uninstall Python versions
 #
-# Usage: pyenv uninstall [-f|--force] <version>
+# Usage: pyenv uninstall [-f|--force] <version> ...
 #
 #    -f  Attempt to remove the specified version without prompting
 #        for confirmation. If the version does not exist, do not
@@ -33,14 +33,17 @@ if [ "$1" = "-f" ] || [ "$1" = "--force" ]; then
   shift
 fi
 
-[ "$#" -eq 1 ] || usage 1 >&2
+[ "$#" -gt 0 ] || usage 1 >&2
 
-DEFINITION="$1"
-case "$DEFINITION" in
-"" | -* )
-  usage 1 >&2
-  ;;
-esac
+versions=("$@")
+
+for version in "${versions[@]}"; do
+  case "$version" in
+  "" | -* )
+    usage 1 >&2
+    ;;
+  esac
+done
 
 declare -a before_hooks after_hooks
 
@@ -59,29 +62,36 @@ IFS=$'\n' scripts=(`pyenv-hooks uninstall`)
 IFS="$OLDIFS"
 for script in "${scripts[@]}"; do source "$script"; done
 
+uninstall-python() {
+  local DEFINITION="$1"
 
-VERSION_NAME="${DEFINITION##*/}"
-PREFIX="${PYENV_ROOT}/versions/${VERSION_NAME}"
+  local VERSION_NAME="${DEFINITION##*/}"
+  local PREFIX="${PYENV_ROOT}/versions/${VERSION_NAME}"
 
-if [ -z "$FORCE" ]; then
-  if [ ! -d "$PREFIX" ]; then
-    echo "pyenv: version \`$VERSION_NAME' not installed" >&2
-    exit 1
+  if [ -z "$FORCE" ]; then
+    if [ ! -d "$PREFIX" ]; then
+      echo "pyenv: version \`$VERSION_NAME' not installed" >&2
+      exit 1
+    fi
+
+    read -p "pyenv: remove $PREFIX? [y|N] "
+    case "$REPLY" in
+    y | Y | yes | YES ) ;;
+    * ) exit 1 ;;
+    esac
   fi
 
-  read -p "pyenv: remove $PREFIX? [y|N] "
-  case "$REPLY" in
-  y | Y | yes | YES ) ;;
-  * ) exit 1 ;;
-  esac
-fi
+  for hook in "${before_hooks[@]}"; do eval "$hook"; done
 
-for hook in "${before_hooks[@]}"; do eval "$hook"; done
+  if [ -d "$PREFIX" ]; then
+    rm -rf "$PREFIX"
+    pyenv-rehash
+    echo "pyenv: $VERSION_NAME uninstalled"
+  fi
 
-if [ -d "$PREFIX" ]; then
-  rm -rf "$PREFIX"
-  pyenv-rehash
-  echo "pyenv: $VERSION_NAME uninstalled"
-fi
+  for hook in "${after_hooks[@]}"; do eval "$hook"; done
+}
 
-for hook in "${after_hooks[@]}"; do eval "$hook"; done
+for version in "${versions[@]}"; do
+  uninstall-python "$version"
+done

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -899,7 +899,7 @@ build_package_micropython() {
     "$MAKE" $MAKE_OPTS
     cd ../ports/unix
     "$MAKE" $MAKE_OPTS axtls
-    "$MAKE" $MAKE_OPTS CFLAGS_EXTRA="-DMICROPY_PY_SYS_PATH_DEFAULT='\"${PREFIX_PATH}/lib/micropython\"' $CFLAGS_EXTRA"
+    "$MAKE" $MAKE_OPTS CFLAGS_EXTRA="-DMICROPY_PY_SYS_PATH_DEFAULT='\".frozen:${PREFIX_PATH}/lib/micropython\"' $CFLAGS_EXTRA"
     "$MAKE" install $MAKE_INSTALL_OPTS PREFIX="${PREFIX_PATH}"
     ln -fs micropython "${PREFIX_PATH}/bin/python"
     mkdir -p "${PREFIX_PATH}/lib/micropython"

--- a/plugins/python-build/share/python-build/3.11.0rc1
+++ b/plugins/python-build/share/python-build/3.11.0rc1
@@ -3,7 +3,7 @@ export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.1n" "https://www.openssl.org/source/openssl-1.1.1n.tar.gz#40dceb51a4f6a5275bde0e6bf20ef4b91bfc32ed57c0552e2e8e15463372b17a" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
 if has_tar_xz_support; then
-    install_package "Python-3.11.0b5" "https://www.python.org/ftp/python/3.11.0/Python-3.11.0b5.tar.xz#3810bd22f7dc34a99c2a2eb4b85264a4df4f05ef59c4e0ccc2ea82ee9c491698" standard verify_py311 copy_python_gdb ensurepip
+    install_package "Python-3.11.0rc1" "https://www.python.org/ftp/python/3.11.0/Python-3.11.0rc1.tar.xz#53a5377c37a8a2c6da075b14eb9d63374579f7f3c718fa20f0a1fbb0e94a922b" standard verify_py311 copy_python_gdb ensurepip
 else
-    install_package "Python-3.11.0b5" "https://www.python.org/ftp/python/3.11.0/Python-3.11.0b5.tgz#3f7d1a4ab0e64425f4ffd92d49de192ad2ee1c62bc52e3877e9f7b254c702e60" standard verify_py311 copy_python_gdb ensurepip
+    install_package "Python-3.11.0rc1" "https://www.python.org/ftp/python/3.11.0/Python-3.11.0rc1.tgz#456f32a8d66e7cae226478a74c3ebb358bae09eba0b8537f47d7b2790f65a1f0" standard verify_py311 copy_python_gdb ensurepip
 fi

--- a/plugins/python-build/share/python-build/micropython-1.18
+++ b/plugins/python-build/share/python-build/micropython-1.18
@@ -1,0 +1,4 @@
+has_tar_xz_support \
+  && { install=install_package; src="https://micropython.org/resources/source/micropython-1.18.tar.xz#96fc71b42ed331c64e1adc5a830ec4f29f2975c23e8751109c03f32b80fa3eb4"; } \
+  || { install=install_zip; src="https://micropython.org/resources/source/micropython-1.18.zip#90fa8049cf275310638b9e9c77121f6042f7250b814ef622f9522befde009f57"; }
+$install micropython-1.18 "$src" micropython

--- a/plugins/python-build/share/python-build/micropython-1.19.1
+++ b/plugins/python-build/share/python-build/micropython-1.19.1
@@ -1,0 +1,4 @@
+has_tar_xz_support \
+  && { install=install_package; src="https://micropython.org/resources/source/micropython-1.19.1.tar.xz#940e3815e8c425c6eaed3a2aa30d320220cc012a2654b6e086e1b6f0567df350"; } \
+  || { install=install_zip; src="https://micropython.org/resources/source/micropython-1.19.1.zip#7047ce208627457c6881850527edb78189a1855a974aa34e2d929c9a3b3c5cc3"; }
+$install micropython-1.19.1 "$src" micropython

--- a/plugins/python-build/test/compiler.bats
+++ b/plugins/python-build/test/compiler.bats
@@ -115,6 +115,6 @@ DEF
 
     #assert_success
     assert_output <<OUT
-CFLAGS_EXTRA=-DMICROPY_PY_SYS_PATH_DEFAULT='"${TMP}/install/lib/micropython"' -Wno-floating-conversion
+CFLAGS_EXTRA=-DMICROPY_PY_SYS_PATH_DEFAULT='".frozen:${TMP}/install/lib/micropython"' -Wno-floating-conversion
 OUT
 }

--- a/plugins/python-build/test/pyenv.bats
+++ b/plugins/python-build/test/pyenv.bats
@@ -195,12 +195,28 @@ OUT
   unstub pyenv-help
 }
 
-@test "too many arguments for pyenv-uninstall" {
-  stub pyenv-help 'uninstall : true'
+@test "more than one argument for pyenv-uninstall" {
+  mkdir -p "${PYENV_ROOT}/versions/3.4.1"
+  mkdir -p "${PYENV_ROOT}/versions/3.4.2"
+  run pyenv-uninstall -f 3.4.1 3.4.2
 
-  run pyenv-uninstall 3.4.1 3.4.2
+  assert_success
+  refute [ -d "${PYENV_ROOT}/versions/3.4.1" ]
+  refute [ -d "${PYENV_ROOT}/versions/3.4.2" ]
+}
+
+@test "invalid arguments for pyenv-uninstall" {
+  mkdir -p "${PYENV_ROOT}/versions/3.10.3"
+  mkdir -p "${PYENV_ROOT}/versions/3.10.4"
+
+  run pyenv-uninstall -f 3.10.3 --invalid-option 3.10.4
   assert_failure
-  unstub pyenv-help
+
+  assert [ -d "${PYENV_ROOT}/versions/3.10.3" ]
+  assert [ -d "${PYENV_ROOT}/versions/3.10.4" ]
+
+  rmdir "${PYENV_ROOT}/versions/3.10.3"
+  rmdir "${PYENV_ROOT}/versions/3.10.4"
 }
 
 @test "show help for pyenv-uninstall" {


### PR DESCRIPTION
Make sure you have checked all steps below.

### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)

### Description
- [x] Here are some details about my PR

Github released ubuntu-22.04 and macos-12 from beta
and deprecated ubuntu-18.04 and macos-10.15, due to dropping by 2013.

### Tests
- [x] My PR adds the following unit tests (if any)
N/A